### PR TITLE
<TEST> : test 'Waived workday list, no duplicate' in workday-waiver.js

### DIFF
--- a/__tests__/__renderer__/workday-waiver.js
+++ b/__tests__/__renderer__/workday-waiver.js
@@ -26,7 +26,8 @@ const {
     clearWaiverList,
     loadHolidaysTable,
     initializeHolidayInfo,
-    refreshDataForTest
+    refreshDataForTest,
+    addHolidaysAsWaiver
 } = require('../../src/workday-waiver');
 import { showDialog } from '../../js/window-aux.js';
 
@@ -149,6 +150,17 @@ describe('Test Workday Waiver Window', function()
             addTestWaiver('2020-07-16', 'some reason');
             const waiver = addTestWaiver('2020-07-16', 'some reason');
             expect(waiver).toBeFalsy();
+        });
+
+        test('Waived workday list, no duplicate', () =>
+        {
+            const day = 'test day';
+            const reason =  'test reason';
+            addHolidayToList(day, reason);
+            addTestWaiver(day, reason);
+            addHolidaysAsWaiver();
+            const rowLength = $('#waiver-list-table tbody tr').length;
+            expect(rowLength).toBe(1);
         });
 
         test('Range does not contain any working day', () =>

--- a/src/workday-waiver.js
+++ b/src/workday-waiver.js
@@ -487,5 +487,6 @@ module.exports = {
     setDates,
     setHours,
     toggleAddButton,
-    refreshDataForTest
+    refreshDataForTest,
+    addHolidaysAsWaiver
 };


### PR DESCRIPTION
When there is the same vacation in Waived workday list and Holidaylist, test check for overlapping in HTML tbody

#### Related issue
Closes #<!--Related issue-->

#### Context / Background
<!--
- Briefly explain the purpose of the PR by providing a summary of the context
-->

I added a test code to workday-waiver.js that corrects duplicate html when I select and add a national holiday and then do the same again.

#### What change is being introduced by this PR?
<!--
- How did you approach this problem?
- What changes did you make to achieve the goal?
- What are the indirect and direct consequences of the change?
-->

Added the 'Waived workday list, no duplicate' test function and imported the necessary addHolidaysAsWaiver function.

#### How will this be tested?
<!--
- How will you verify whether your changes worked as expected once merged?
-->

"npm run test:jest workday-waiver.js"

----
<!--
- If this PR is for translation, please mark the box below
-->
- [ ] I confirm I'm a native or fluent speaker of the language I'm translating to.
