### PR TITLE
Add describe and test (not delete waiver)

### DIFF
--- a/__tests__/__renderer__/workday-waiver.js
+++ b/__tests__/__renderer__/workday-waiver.js
@@ -212,6 +212,23 @@ describe('Test Workday Waiver Window', function()
         });
     });
 
+    describe('Not Delete waiver', () =>
+    {
+        test('Waiver was not deleted', () =>
+        {
+            prepareMockup();
+            addTestWaiver('2020-07-16', 'some reason');
+            const deleteBtn = document.querySelectorAll('#waiver-list-table .delete-btn')[0];
+            showDialog.mockImplementation((options, cb) =>
+            {
+                cb({ response: -1 });
+            });
+            deleteEntryOnClick({target: deleteBtn});
+            const length = document.querySelectorAll('#waiver-list-table .delete-btn').length;
+            expect(length).toBe(1);
+        });
+    });
+
     describe('Populating', () =>
     {
         const hd = new Holidays();


### PR DESCRIPTION
Added a test function to solve the problem that rows are deleted depending on language selection when clicking the close button of the notification window created when the delete button is clicked

#### What change is being introduced by this PR?
<!--
- How did you approach this problem?
- What changes did you make to achieve the goal?
- What are the indirect and direct consequences of the change?
-->

Add describe and test (not delete waiver)

#### How will this be tested?
<!--
- How will you verify whether your changes worked as expected once merged?
-->

'npm run test:jest'

----
<!--
- If this PR is for translation, please mark the box below
-->
- [ ] I confirm I'm a native or fluent speaker of the language I'm translating to.
